### PR TITLE
(metadata.json) bump-apt-version-constraint

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -470,7 +470,7 @@ define docker::run (
         $detect_changes = Deferred('docker_params_changed', [$docker_params_changed_args])
 
         notify { "${title}_docker_params_changed":
-          message  => $detect_changes,
+          message => $detect_changes,
         }
       }
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -319,7 +319,7 @@ class docker::service (
 
     $dirs.each |$dir| {
       file { $dir:
-        ensure  => directory,
+        ensure => directory,
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 4.4.1 < 10.0.0"
+      "version_requirement": ">= 4.4.1 < 11.0.0"
     },
     {
       "name": "puppetlabs/powershell",


### PR DESCRIPTION
## Summary
Bump the minimum constraint of APT to include 10.x. As well as fix spacing issues in service.pp and run.pp, which cause the CI to fail.

## Additional Context

- [ ] Allows the use of APT 10.x in enviroments
- [ ] Fixes line spacing issues in 2 pp files 


## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)